### PR TITLE
Fix resources path for cross-plattform

### DIFF
--- a/AppWindow.cs
+++ b/AppWindow.cs
@@ -72,7 +72,7 @@ namespace KeyOverlay {
             Text textLeft = CreateItems.CreateText(_k1Key.KeyLetter, squareLeft);
             Text textRight = CreateItems.CreateText(_k2Key.KeyLetter, squareRight);
 
-            Sprite image = new Sprite(new Texture(@"Resources\fading.png"));
+            Sprite image = new Sprite(new Texture(Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "Resources", "fading.png"))));
             image.Scale = new Vector2f(image.Scale.X * _window.Size.X / 480f, image.Scale.Y *_ratioY);
 
             List<RectangleShape> rectListLeft = new();

--- a/CreateItems.cs
+++ b/CreateItems.cs
@@ -1,5 +1,6 @@
 ﻿using SFML.Graphics;
 using SFML.System;
+using System.IO;
 
 namespace KeyOverlay {
     public static class CreateItems {
@@ -22,7 +23,7 @@ namespace KeyOverlay {
         }
 
         public static Text CreateText(string key, RectangleShape square) {
-            Font font = new Font(@"Resources\consolab.ttf");
+            Font font = new Font(Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "Resources", "consolab.ttf")));
             Text text = new Text(key, font);
             text.CharacterSize = (uint)(50 * square.Size.X / 140);
             text.Style = Text.Styles.Bold;


### PR DESCRIPTION
```bash
[nzxl@arch net5.0]$ dotnet KeyOverlay.dll
Failed to load font "Resources\consolab.ttf" (failed to create the font face)
Unhandled exception. SFML.LoadingFailedException: Failed to load font from file Resources\consolab.ttf
   at SFML.Graphics.Font..ctor(String filename)
   at KeyOverlay.CreateItems.CreateText(String key, RectangleShape square) in C:\Users\Daniel\source\repos\KeyOverlay\KeyOverlay\CreateItems.cs:line 30
   at KeyOverlay.AppWindow.Run() in C:\Users\Daniel\source\repos\KeyOverlay\KeyOverlay\AppWindow.cs:line 72
   at KeyOverlay.Program.Main(String[] args) in C:\Users\Daniel\source\repos\KeyOverlay\KeyOverlay\Program.cs:line 5
Aborted (core dumped)
```

Not really great how paths are handled, but should be working now on every plattform with this changes.